### PR TITLE
Adding GitHubID prompt

### DIFF
--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -173,6 +173,10 @@ class DevToolsCommand extends ConsoleCommand
 
                 break;
 
+            case 'githubid':
+                // GitHubID can be blank, so nothing here
+                break;
+
             case 'email':
                 if (!preg_match('/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/', $value)) {
                     throw new \RuntimeException('Not a valid email address');

--- a/cli/NewPluginCommand.php
+++ b/cli/NewPluginCommand.php
@@ -45,6 +45,12 @@ class NewPluginCommand extends DevToolsCommand
                 'The name/username of the developer'
             )
             ->addOption(
+                'githubid',
+                'gh',
+                InputOption::VALUE_OPTIONAL,
+                'The developer\'s GitHub ID'
+            )
+            ->addOption(
                 'email',
                 'e',
                 InputOption::VALUE_OPTIONAL,
@@ -73,7 +79,8 @@ class NewPluginCommand extends DevToolsCommand
             'description'   => $this->input->getOption('description'),
             'author'        => [
                 'name'      => $this->input->getOption('developer'),
-                'email'     => $this->input->getOption('email')
+                'email'     => $this->input->getOption('email'),
+                'githubid'  => $this->input->getOption('githubid')
             ]
         ];
 
@@ -110,6 +117,16 @@ class NewPluginCommand extends DevToolsCommand
             $this->component['author']['name'] = $helper->ask($this->input, $this->output, $question);
         }
 
+
+        if (!$this->options['author']['githubid']) {
+            $question = new Question('Enter <yellow>GitHub ID</yellow> (can be blank): ');
+            $question->setValidator(function ($value) {
+                return $this->validate('githubid', $value);
+            });
+
+            $this->component['author']['githubid'] = $helper->ask($this->input, $this->output, $question);
+        }
+
         if (!$this->options['author']['email']) {
             $question = new Question('Enter <yellow>Developer Email</yellow>: ');
             $question->setValidator(function ($value) {
@@ -120,6 +137,10 @@ class NewPluginCommand extends DevToolsCommand
         }
 
         $this->component['template'] = 'blank';
+
+        if ( ($this->component['author']['githubid'] === null) || (trim($this->component['author']['githubid']) === '') ) {
+            $this->component['author']['githubid'] = $this->component['author']['name'];
+        }
 
         $this->createComponent();
     }

--- a/components/plugin/blank/blueprints.yaml.twig
+++ b/components/plugin/blank/blueprints.yaml.twig
@@ -5,11 +5,11 @@ icon: plug
 author:
   name: {{ component.author.name }}
   email: {{ component.author.email }}
-homepage: https://github.com/{{ component.author.name|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}
+homepage: https://github.com/{{ component.author.githubid|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}
 demo: http://demo.yoursite.com
 keywords: grav, plugin, etc
-bugs: https://github.com/{{ component.author.name|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}/issues
-docs: https://github.com/{{ component.author.name|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}/blob/develop/README.md
+bugs: https://github.com/{{ component.author.githubid|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}/issues
+docs: https://github.com/{{ component.author.githubid|hyphenize }}/grav-plugin-{{ component.name|hyphenize }}/blob/develop/README.md
 license: MIT
 
 form:


### PR DESCRIPTION
This adds a prompt for the developer's GitHub ID. If blank, it uses the name as provided. The `blueprints.yaml` file has also been modified to use the `githubid` property in generating GitHub URLs.
