### PR TITLE
Suggesting a fuller README template

### DIFF
--- a/components/plugin/blank/README.md.twig
+++ b/components/plugin/blank/README.md.twig
@@ -1,37 +1,37 @@
-{% set cTitle = (component.name|titleize) %}
-{% set cHyphen = (component.name|hyphenize) %}
-{% set uHyphen = (component.author.name|hyphenize) %}
-# {{ cTitle }} Plugin
+{% set component_title = (component.name|titleize) %}
+{% set component_hyphenated = (component.name|hyphenize) %}
+{% set developer_hyphenated = (component.author.name|hyphenize) %}
+# {{ component_title }} Plugin
 
 **This README.md file should be modified to describe the features, installation, configuration, and general usage of this plugin.**
 
-The **{{ cTitle }}** Plugin is for [Grav CMS](http://github.com/getgrav/grav). {{ component.description }}
+The **{{ component_title }}** Plugin is for [Grav CMS](http://github.com/getgrav/grav). {{ component.description }}
 
 ## Installation
 
-Installing the {{ cTitle }} plugin can be done in one of two ways. The GPM (Grav Package Manager) installation method enables you to quickly and easily install the plugin with a simple terminal command, while the manual method enables you to do so via a zip file.
+Installing the {{ component_title }} plugin can be done in one of two ways. The GPM (Grav Package Manager) installation method enables you to quickly and easily install the plugin with a simple terminal command, while the manual method enables you to do so via a zip file.
 
 ### GPM Installation (Preferred)
 
 The simplest way to install this plugin is via the [Grav Package Manager (GPM)](http://learn.getgrav.org/advanced/grav-gpm) through your system's terminal (also called the command line).  From the root of your Grav install type:
 
-    bin/gpm install {{ cHyphen }}
+    bin/gpm install {{ component_hyphenated }}
 
-This will install the {{ cTitle }} plugin into your `/user/plugins` directory within Grav. Its files can be found under `/your/site/grav/user/plugins/{{ cHyphen }}`.
+This will install the {{ component_title }} plugin into your `/user/plugins` directory within Grav. Its files can be found under `/your/site/grav/user/plugins/{{ component_hyphenated }}`.
 
 ### Manual Installation
 
-To install this plugin, just download the zip version of this repository and unzip it under `/your/site/grav/user/plugins`. Then, rename the folder to `{{ cHyphen }}`. You can find these files on [GitHub](https://github.com/{{ uHyphen }}/grav-plugin-{{ cHyphen }}) or via [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
+To install this plugin, just download the zip version of this repository and unzip it under `/your/site/grav/user/plugins`. Then, rename the folder to `{{ component_hyphenated }}`. You can find these files on [GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}) or via [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
 
 You should now have all the plugin files under
 
-    /your/site/grav/user/plugins/{{ cHyphen }}
+    /your/site/grav/user/plugins/{{ component_hyphenated }}
 	
 > NOTE: This plugin is a modular component for Grav which requires [Grav](http://github.com/getgrav/grav) and the [Error](https://github.com/getgrav/grav-plugin-error) and [Problems](https://github.com/getgrav/grav-plugin-problems) to operate.
 
 ## Configuration
 
-Before configuring this plugin, you should copy the `user/plugins/{{ cHyphen }}/{{ cHyphen }}.yaml` to `user/config/plugins/{{ cHyphen }}.yaml` and only edit that copy.
+Before configuring this plugin, you should copy the `user/plugins/{{ component_hyphenated }}/{{ component_hyphenated }}.yaml` to `user/config/plugins/{{ component_hyphenated }}.yaml` and only edit that copy.
 
 Here is the default configuration and an explanation of available options:
 

--- a/components/plugin/blank/README.md.twig
+++ b/components/plugin/blank/README.md.twig
@@ -1,7 +1,53 @@
-# {{ component.name|titleize }} Plugin
+{% set cTitle = (component.name|titleize) %}
+{% set cHyphen = (component.name|hyphenize) %}
+{% set uHyphen = (component.author.name|hyphenize) %}
+# {{ cTitle }} Plugin
 
-The **{{ component.name|titleize }}** Plugin is for [Grav CMS](http://github.com/getgrav/grav).  This README.md file should be modified to describe the features, installation, configuration, and general usage of this plugin.
+**This README.md file should be modified to describe the features, installation, configuration, and general usage of this plugin.**
 
-## Description
+The **{{ cTitle }}** Plugin is for [Grav CMS](http://github.com/getgrav/grav). {{ component.description }}
 
-{{ component.description }}
+## Installation
+
+Installing the {{ cTitle }} plugin can be done in one of two ways. The GPM (Grav Package Manager) installation method enables you to quickly and easily install the plugin with a simple terminal command, while the manual method enables you to do so via a zip file.
+
+### GPM Installation (Preferred)
+
+The simplest way to install this plugin is via the [Grav Package Manager (GPM)](http://learn.getgrav.org/advanced/grav-gpm) through your system's terminal (also called the command line).  From the root of your Grav install type:
+
+    bin/gpm install {{ cHyphen }}
+
+This will install the {{ cTitle }} plugin into your `/user/plugins` directory within Grav. Its files can be found under `/your/site/grav/user/plugins/{{ cHyphen }}`.
+
+### Manual Installation
+
+To install this plugin, just download the zip version of this repository and unzip it under `/your/site/grav/user/plugins`. Then, rename the folder to `{{ cHyphen }}`. You can find these files on [GitHub](https://github.com/{{ uHyphen }}/grav-plugin-{{ cHyphen }}) or via [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
+
+You should now have all the plugin files under
+
+    /your/site/grav/user/plugins/{{ cHyphen }}
+	
+> NOTE: This plugin is a modular component for Grav which requires [Grav](http://github.com/getgrav/grav) and the [Error](https://github.com/getgrav/grav-plugin-error) and [Problems](https://github.com/getgrav/grav-plugin-problems) to operate.
+
+## Configuration
+
+Before configuring this plugin, you should copy the `user/plugins/{{ cHyphen }}/{{ cHyphen }}.yaml` to `user/config/plugins/{{ cHyphen }}.yaml` and only edit that copy.
+
+Here is the default configuration and an explanation of available options:
+
+```yaml
+enabled: true
+```
+
+## Usage
+
+**Describe how to use the plugin.**
+
+## Credits
+
+**Did you incorporate third-party code? Want to thank somebody?**
+
+## To Do
+
+- [ ] Future plans, if any
+


### PR DESCRIPTION
Just a suggestion. Feedback warmly welcomed. 

* I used `set` statements to avoid twig running the same filter a hundred times.

* This does *not* include the `feature/githubid` branch (PR #5). Should you choose to incorporate that branch as well, then I would change line three of the twig file to `{% set uHyphen = (component.author.githubid|hyphenize) %}`.

