### PR TITLE
Fix inherited parent theme PHP class

### DIFF
--- a/components/theme/inheritence/theme.php.twig
+++ b/components/theme/inheritence/theme.php.twig
@@ -3,7 +3,7 @@ namespace Grav\Theme;
 
 use Grav\Common\Theme;
 
-class {{ component.name|camelize }} extends Theme
+class {{ component.name|camelize }} extends {{ component.extends|camelize }}
 {
     // Access plugin events in this class
 }


### PR DESCRIPTION
The PHP theme class in its Twig file is hardcoded to inherit from `Theme` but should inherit from the parent theme instead (at least as per the [grav learn docs](https://learn.getgrav.org/themes/customization#theme-inheritance)).