### PR TITLE
Add docs header to theme blueprints templates

### DIFF
--- a/components/theme/inheritance/blueprints.yaml.twig
+++ b/components/theme/inheritance/blueprints.yaml.twig
@@ -10,4 +10,5 @@ demo: http://demo.yoursite.com
 keywords: grav, theme, etc
 bugs: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/issues
 readme: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/blob/develop/README.md
+docs: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/blob/develop/README.md
 license: MIT

--- a/components/theme/pure-blank/blueprints.yaml.twig
+++ b/components/theme/pure-blank/blueprints.yaml.twig
@@ -10,6 +10,7 @@ demo: http://demo.yoursite.com
 keywords: grav, theme, etc
 bugs: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/issues
 readme: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/blob/develop/README.md
+docs: https://github.com/{{ component.author.name|hyphenize }}/grav-theme-{{ component.name|hyphenize }}/blob/develop/README.md
 license: MIT
 
 form:


### PR DESCRIPTION
This supports direct links from Grav theme repo's web interface. Not sure about other theme metadata renderings so left `readme` header in.

Resolves #34.