### PR TITLE
Create assets block in pure-blank theme base template

### DIFF
--- a/components/theme/pure-blank/templates/partials/base.html.twig
+++ b/components/theme/pure-blank/templates/partials/base.html.twig
@@ -18,12 +18,15 @@
         {% do assets.addCss('https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css', 99) %}
         {% do assets.addCss('theme://css/custom.css', 98) %}
     {% endblock %}
-    {{ assets.css() }}
 
     {% block javascripts %}
         {% do assets.addJs('jquery', 100) %}
     {% endblock %}
-    {{ assets.js() }}
+
+    {% block assets %}
+        {{ assets.css() }}
+        {{ assets.js() }}
+    {% endblock %}
 
 {% endblock head%}
 </head>


### PR DESCRIPTION
Facilitates support for deferred assets block as per _[Important Theme Updates](https://getgrav.org/blog/important-theme-updates)_.

Stops short of declaring the block as deferred to maintain support for older versions. Block can be easily overridden as deferred.