### PR TITLE
Added offline option to skip name collision check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.2.4
+## 10/15/2019
+
+1. [](#improved)
+    * Added the ability to use devtools without an online connection to GPM
+
+
 # v1.2.3
 ## 06/20/2019
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You should now have all the plugin files under
 
 	/your/site/grav/user/plugins/devtools
 	
+## Configuration
+
+By default, devtools will perform a check with the online gpm repository to ensure name-collision avoidance. If you wish to not perform this online check, change the devtools.yaml at `user/config/plugins` from `collision_check: true` to `collision_check: false`.
+
 # Usage
 
 ## Plugin Scaffolding

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -24,4 +24,13 @@ form:
         0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
-
+    collision_check:
+      type: toggle
+      label: PLUGIN_DEVTOOLS.COLLISION_CHECK
+      highlight: 1
+      default: 1
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool

--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -241,14 +241,24 @@ class DevToolsCommand extends ConsoleCommand
      */
     protected function validate($type, $value, $extra = '')
     {
+        $grav = Grav::instance();
+        $config = $grav['config'];
         switch ($type) {
             case 'name':
-                //Check If name
+                // Check If name
                 if ($value === null || trim($value) === '') {
                     throw new \RuntimeException('Name cannot be empty');
                 }
-                if (false !== $this->gpm->findPackage($value)) {
-                    throw new \RuntimeException('Package name exists in GPM');
+
+                // Check for name collision with online gpm.
+                $collision_check = $config->get('plugins.devtools.collision_check');
+                if ( $collision_check == true) {
+                    if (false !== $this->gpm->findPackage($value)) {
+                        throw new \RuntimeException('Package name exists in GPM');
+                    }
+                } else {
+                    $this->output->writeln('<red>Warning</red>: Devtools is configured for "<cyan>collision_check</cyan>: <red>false</red>".');
+                    $this->output->writeln('Please be aware that your project\'s plugin or theme name may conflict with an existing plugin or theme.');
                 }
 
                 // Check if it's reserved

--- a/devtools.yaml
+++ b/devtools.yaml
@@ -1,2 +1,2 @@
 enabled: true
-
+collision_check: true

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,0 +1,3 @@
+en:
+  PLUGIN_DEVTOOLS:
+    COLLISION_CHECK: Online Name Collision Check


### PR DESCRIPTION
Addresses small use case where the developer is working offline, and a name collision check isn't possible via gpm.