### PR TITLE
Improve inherited theme stream references

### DIFF
--- a/components/theme/inheritance/theme.yaml.twig
+++ b/components/theme/inheritance/theme.yaml.twig
@@ -4,5 +4,5 @@ streams:
      type: ReadOnlyStream
      prefixes:
        '':
-         - user/themes/{{ component.name|hyphenize }}
-         - user/themes/{{ component.extends }}
+         - 'user://themes/{{ component.name|hyphenize }}'
+         - 'user://themes/{{ component.extends }}'


### PR DESCRIPTION
I found that the existing relative file system references of the form 'user/themes/foo' did not work in multisite environments. Using a 'user' scheme stream URL works in both multi- and single site installs.