### PR TITLE
Make name key Composer 2.0 compatible

### DIFF
--- a/components/plugin/blank/composer.json.twig
+++ b/components/plugin/blank/composer.json.twig
@@ -1,6 +1,6 @@
 {% set githubid = component.author.githubid ?: component.author.name|hyphenize -%}
 {
-  "name": "{{ githubid }}/{{ component.name|hyphenize }}",
+  "name": "{{ githubid|lower }}/{{ component.name|hyphenize }}",
   "type": "grav-plugin",
   "description": "{{ component.description }}",
   "keywords": ["plugin"],


### PR DESCRIPTION
- Uppercase characters in `name` cause a deprecation warning (or error in 2.0).
- This commit coerces the developer name to lowercase within `name`.
- Plugin name is already coerced to lowercase elsewhere.