### PR TITLE
Add 'gpm' key to blueprints

### DIFF
--- a/components/plugin/blank/blueprints.yaml.twig
+++ b/components/plugin/blank/blueprints.yaml.twig
@@ -3,6 +3,7 @@ name: {{ component.name|titleize }}
 slug: {{ component.name|hyphenize }}
 type: plugin
 version: 0.1.0
+gpm: true
 description: {{ component.description }}
 icon: plug
 author:

--- a/components/theme/inheritance/blueprints.yaml.twig
+++ b/components/theme/inheritance/blueprints.yaml.twig
@@ -3,6 +3,7 @@ name: {{ component.name|titleize }}
 slug: {{ component.name|hyphenize }}
 type: theme
 version: 0.1.0
+gpm: true
 description: {{ component.description }}
 icon: rebel
 author:

--- a/components/theme/pure-blank/blueprints.yaml.twig
+++ b/components/theme/pure-blank/blueprints.yaml.twig
@@ -3,6 +3,7 @@ name: {{ component.name|titleize }}
 slug: {{ component.name|hyphenize }}
 type: theme
 version: 0.1.0
+gpm: true
 description: {{ component.description }}
 icon: rebel
 author:


### PR DESCRIPTION
- The 'gpm' key allows disabling of GPM updates.
- Adding it to the blueprint templates is useful for developers, and particularly so for those of us developing for clients.