### PR TITLE
Use stream URLs in inheritance theme YAML files

### DIFF
--- a/components/theme/inheritance/theme.yaml.twig
+++ b/components/theme/inheritance/theme.yaml.twig
@@ -4,5 +4,5 @@ streams:
      type: ReadOnlyStream
      prefixes:
        '':
-         - user/themes/{{ component.name|hyphenize }}
-         - user/themes/{{ component.extends }}
+         - 'user://themes/{{ component.name|hyphenize }}'
+         - 'user://themes/{{ component.extends }}'


### PR DESCRIPTION
I noticed simple paths fail with inherited themes on multisite installs ('theme not found' or similar) until I change them to stream URLs.