### PR TITLE
Make use of canonial function

### DIFF
--- a/components/theme/pure-blank/templates/partials/base.html.twig
+++ b/components/theme/pure-blank/templates/partials/base.html.twig
@@ -11,7 +11,7 @@
     {% include 'partials/metadata.html.twig' %}
 
     <link rel="icon" type="image/png" href="{{ url('theme://images/logo.png')|e }}" />
-    <link rel="canonical" href="{{ page.url(true, true)|e }}" />
+    <link rel="canonical" href="{{ page.canonical(true)|e }}" />
 {% endblock head %}
 
 {% block stylesheets %}


### PR DESCRIPTION
I also enabled to include the language prefix, which makes sense for SEO.