### PR TITLE
Clarify 'composer update' message + generate *.php for Grav >= 1.7

### DIFF
--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -244,7 +244,7 @@ class DevToolsCommand extends ConsoleCommand
         $this->output->writeln('Path: <cyan>' . $component_folder . '</cyan>');
         $this->output->writeln('');
         if ($type === 'plugin') {
-            $this->output->writeln('<yellow>Make sure to run `composer update` to initialize the autoloader</yellow>');
+            $this->output->writeln('<yellow>Please run `cd user/plugins/' . $name . '` and `composer update` to initialize the autoloader</yellow>');
             $this->output->writeln('');
         }
 

--- a/components/plugin/blank/plugin.php.twig
+++ b/components/plugin/blank/plugin.php.twig
@@ -24,7 +24,8 @@ class {{ component.name|camelize }}Plugin extends Plugin
     {
         return [
             'onPluginsInitialized' => [
-                ['autoload', 100000], // TODO: Remove when plugin requires Grav >=1.7
+                // Uncomment following line when plugin requires Grav < 1.7
+                // ['autoload', 100000],
                 ['onPluginsInitialized', 0]
             ]
         ];


### PR DESCRIPTION
I would like to suggest two changes:
1. From own experience and from post on forum, the message displayed after creating a 'new-plugin' is confusing when user is not familiar with composer. It is not clear that user must change directory into the folder of the new plugin. See also issue [#61](https://github.com/getgrav/grav-plugin-devtools/issues/61)

   When user creates plugin 'myplugin', new message would be:
   > 'Please run \`cd user/plugins/myplugin\` and \`composer update\` to initialize the autoloader'

2. Since Grav 1.7+ is now the default version people download, I would like to suggest the generated code is for Grav >= 1.7 and show comment when required version of Grav is < 1.7
   ```
   public static function getSubscribedEvents(): array
   {
       return [
           'onPluginsInitialized' => [
               // Uncomment following line when plugin requires Grav < 1.7
               // ['autoload', 100000],
               ['onPluginsInitialized', 0]
           ]
       ];
   }
   ```

