### PR TITLE
Moved offline check to cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ There are **three template creation options**
 2. `inheritance` - This creates a very basic template with minimal files that inherits a base theme.  To find out more about theme inheritance, [check out the subject in more details on the Grav Learn site](https://learn.getgrav.org/themes/customization#theme-inheritance).
 3. `copy` - This allows you to create a new theme based on an existing theme.  This is the simplest way to get started with a new theme by using another theme as the basis.
 
+## Skipping Online Project Name Collision Checking
 
+By default, devtools will check your project's name with the existing gpm ecosystem to ensure no collisions.  In order to skip this check, add an `--offline` or `-o` to your command:
 
+    `bin/plugin devtools new-theme --offline`
+or
 
+    `bin/plugin devtools new-theme -o`

--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -293,8 +293,6 @@ class DevToolsCommand extends ConsoleCommand
      */
     protected function validate(string $type, $value)
     {
-        $grav = Grav::instance();
-        $config = $grav['config'];
         switch ($type) {
             case 'name':
                 // Check If name
@@ -302,15 +300,14 @@ class DevToolsCommand extends ConsoleCommand
                     throw new \RuntimeException('Name cannot be empty');
                 }
 
-                // Check for name collision with online gpm.
-                $collision_check = $config->get('plugins.devtools.collision_check');
-                if ( $collision_check == true) {
+                if (!$this->options['offline']) {
+                    // Check for name collision with online gpm.
                     if (false !== $this->gpm->findPackage($value)) {
                         throw new \RuntimeException('Package name exists in GPM');
                     }
                 } else {
-                    $this->output->writeln('<red>Warning</red>: Devtools is configured for "<cyan>collision_check</cyan>: <red>false</red>".');
-                    $this->output->writeln('Please be aware that your project\'s plugin or theme name may conflict with an existing plugin or theme.');
+                    $this->output->writeln('');
+                    $this->output->writeln('  <red>Warning</red>: Please note that by skipping the online check, your project\'s plugin or theme name may conflict with an existing plugin or theme.');
                 }
 
                 // Check if it's reserved

--- a/cli/NewPluginCommand.php
+++ b/cli/NewPluginCommand.php
@@ -51,6 +51,12 @@ class NewPluginCommand extends DevToolsCommand
                 InputOption::VALUE_OPTIONAL,
                 'The developer\'s email'
             )
+            ->addOption(
+                'offline',
+                'o',
+                InputOption::VALUE_NONE,
+                'Skip online name collision check'
+            )
             ->setDescription('Creates a new Grav plugin with the basic required files')
             ->setHelp('The <info>new-plugin</info> command creates a new Grav instance and performs the creation of a plugin.');
     }
@@ -76,7 +82,8 @@ class NewPluginCommand extends DevToolsCommand
                 'name' => $input->getOption('dev'),
                 'email' => $input->getOption('email'),
                 'githubid' => $input->getOption('github')
-            ]
+            ],
+            'offline' => $input->getOption('offline'),
         ];
 
         $this->validateOptions();

--- a/cli/NewThemeCommand.php
+++ b/cli/NewThemeCommand.php
@@ -52,6 +52,12 @@ class NewThemeCommand extends DevToolsCommand
                 InputOption::VALUE_OPTIONAL,
                 'The developer\'s email'
             )
+            ->addOption(
+                'offline',
+                'o',
+                InputOption::VALUE_NONE,
+                'Skip online name collision check'
+            )
             ->setDescription('Creates a new Grav theme with the basic required files')
             ->setHelp('The <info>new-theme</info> command creates a new Grav instance and performs the creation of a theme.');
     }
@@ -77,7 +83,8 @@ class NewThemeCommand extends DevToolsCommand
                 'name' => $input->getOption('dev'),
                 'email' => $input->getOption('email'),
                 'githubid' => $input->getOption('github'),
-            ]
+            ],
+            'offline' => $input->getOption('offline'),
         ];
 
         $this->validateOptions();


### PR DESCRIPTION
Updated the PR to avoid file conflicts.

This PR moves the offline check flag from the plugin's config yaml to an in-line flag `--offline` or `-o` instead.