### PR TITLE
Update links and default branch name

### DIFF
--- a/components/plugin/blank/README.md.twig
+++ b/components/plugin/blank/README.md.twig
@@ -5,7 +5,7 @@
 
 **This README.md file should be modified to describe the features, installation, configuration, and general usage of the plugin.**
 
-The **{{ component_title }}** Plugin is an extension for [Grav CMS](http://github.com/getgrav/grav). {{ component.description }}
+The **{{ component_title }}** Plugin is an extension for [Grav CMS](https://github.com/getgrav/grav). {{ component.description }}
 
 ## Installation
 
@@ -13,7 +13,7 @@ Installing the {{ component_title }} plugin can be done in one of three ways: Th
 
 ### GPM Installation (Preferred)
 
-To install the plugin via the [GPM](http://learn.getgrav.org/advanced/grav-gpm), through your system's terminal (also called the command line), navigate to the root of your Grav-installation, and enter:
+To install the plugin via the [GPM](https://learn.getgrav.org/cli-console/grav-cli-gpm), through your system's terminal (also called the command line), navigate to the root of your Grav-installation, and enter:
 
     bin/gpm install {{ component_hyphenated }}
 
@@ -21,13 +21,13 @@ This will install the {{ component_title }} plugin into your `/user/plugins`-dir
 
 ### Manual Installation
 
-To install the plugin manually, download the zip-version of this repository and unzip it under `/your/site/grav/user/plugins`. Then rename the folder to `{{ component_hyphenated }}`. You can find these files on [GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}) or via [GetGrav.org](http://getgrav.org/downloads/plugins#extras).
+To install the plugin manually, download the zip-version of this repository and unzip it under `/your/site/grav/user/plugins`. Then rename the folder to `{{ component_hyphenated }}`. You can find these files on [GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}) or via [GetGrav.org](https://getgrav.org/downloads/plugins).
 
 You should now have all the plugin files under
 
     /your/site/grav/user/plugins/{{ component_hyphenated }}
 	
-> NOTE: This plugin is a modular component for Grav which may require other plugins to operate, please see its [blueprints.yaml-file on GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}/blob/master/blueprints.yaml).
+> NOTE: This plugin is a modular component for Grav which may require other plugins to operate, please see its [blueprints.yaml-file on GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}/blob/main/blueprints.yaml).
 
 ### Admin Plugin
 


### PR DESCRIPTION
- `https` in all cases
- update link to GPM docs on `learn.getgrav.org`: 302 redirect should presumably head to the right minor version?
- replace `master` with `main` (See [Renaming the default branch from `master`](https://github.com/github/renaming))