### PR TITLE
Removed platform-config

### DIFF
--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -308,9 +308,14 @@ class DevToolsCommand extends ConsoleCommand
     {
         switch ($type) {
             case 'name':
-                // Check If name
+                // Check if name is empty
                 if ($value === null || trim($value) === '') {
                     throw new \RuntimeException('Name cannot be empty');
+                }
+
+                // Check if name starts with a numeric character
+                if (is_numeric($value[0])) {
+                    throw new \RuntimeException('Name must start with a alphanumeric character [a-z|A-Z]');
                 }
 
                 if (!$this->options['offline']) {

--- a/classes/DevToolsCommand.php
+++ b/classes/DevToolsCommand.php
@@ -315,7 +315,7 @@ class DevToolsCommand extends ConsoleCommand
 
                 // Check if name starts with a numeric character
                 if (is_numeric($value[0])) {
-                    throw new \RuntimeException('Name must start with a alphanumeric character [a-z|A-Z]');
+                    throw new \RuntimeException('Name must start with an alphabetic character (A-Z, a-z)');
                 }
 
                 if (!$this->options['offline']) {

--- a/components/plugin/blank/composer.json.twig
+++ b/components/plugin/blank/composer.json.twig
@@ -21,10 +21,5 @@
       "Grav\\Plugin\\{{ component.name|camelize }}\\": "classes/"
     },
     "classmap":  ["{{ component.name|hyphenize }}.php"]
-  },
-  "config": {
-    "platform": {
-      "php": "7.1.3"
-    }
   }
 }

--- a/components/plugin/flex/composer.json.twig
+++ b/components/plugin/flex/composer.json.twig
@@ -21,10 +21,5 @@
       "Grav\\Plugin\\{{ component.name|camelize }}\\": "classes/"
     },
     "classmap":  ["{{ component.name|hyphenize }}.php"]
-  },
-  "config": {
-    "platform": {
-      "php": "7.1.3"
-    }
   }
 }


### PR DESCRIPTION
Removed the platform configuration part as it unnecessarily constrains the installation of dependencies. As adviced by Ole Vik after research by pamtbaau, see Grav Forum post [Unable to use third party library in new plugin](https://discourse.getgrav.org/t/unable-to-use-third-party-library-in-new-plugin/23342/8)