### PR TITLE
Updated default README for plugins

### DIFF
--- a/components/plugin/blank/README.md.twig
+++ b/components/plugin/blank/README.md.twig
@@ -9,7 +9,7 @@ The **{{ component_title }}** Plugin is an extension for [Grav CMS](https://gith
 
 ## Installation
 
-Installing the {{ component_title }} plugin can be done in one of three ways: The GPM (Grav Package Manager) installation method lets you quickly install the plugin with a simple terminal command, the admin method lets you do so via the Admin Plugi, and the manual method lets you do so via a zip file.
+Installing the {{ component_title }} plugin can be done in one of three ways: The GPM (Grav Package Manager) installation method lets you quickly install the plugin with a simple terminal command, the admin method lets you do so via the Admin Plugin, and the manual method lets you do so via a zip file.
 
 ### GPM Installation (Preferred)
 

--- a/components/plugin/blank/README.md.twig
+++ b/components/plugin/blank/README.md.twig
@@ -9,7 +9,7 @@ The **{{ component_title }}** Plugin is an extension for [Grav CMS](https://gith
 
 ## Installation
 
-Installing the {{ component_title }} plugin can be done in one of three ways: The GPM (Grav Package Manager) installation method lets you quickly install the plugin with a simple terminal command, the manual method lets you do so via a zip file, and the admin method lets you do so via the Admin Plugin.
+Installing the {{ component_title }} plugin can be done in one of three ways: The GPM (Grav Package Manager) installation method lets you quickly install the plugin with a simple terminal command, the admin method lets you do so via the Admin Plugi, and the manual method lets you do so via a zip file.
 
 ### GPM Installation (Preferred)
 
@@ -18,6 +18,10 @@ To install the plugin via the [GPM](https://learn.getgrav.org/cli-console/grav-c
     bin/gpm install {{ component_hyphenated }}
 
 This will install the {{ component_title }} plugin into your `/user/plugins`-directory within Grav. Its files can be found under `/your/site/grav/user/plugins/{{ component_hyphenated }}`.
+
+### Admin Plugin
+
+If you use the Admin Plugin, you can install the plugin directly by browsing the `Plugins`-menu and clicking on the `Add` button.
 
 ### Manual Installation
 
@@ -29,13 +33,11 @@ You should now have all the plugin files under
 	
 > NOTE: This plugin is a modular component for Grav which may require other plugins to operate, please see its [blueprints.yaml-file on GitHub](https://github.com/{{ developer_hyphenated }}/grav-plugin-{{ component_hyphenated }}/blob/main/blueprints.yaml).
 
-### Admin Plugin
-
-If you use the Admin Plugin, you can install the plugin directly by browsing the `Plugins`-menu and clicking on the `Add` button.
-
 ## Configuration
 
-Before configuring this plugin, you should copy the `user/plugins/{{ component_hyphenated }}/{{ component_hyphenated }}.yaml` to `user/config/plugins/{{ component_hyphenated }}.yaml` and only edit that copy.
+If you use the Admin Plugin, a file with your configuration named {{component_hyphenated}}.yaml will be automatically created and saved in the `user/config/plugins/`-folder once the configuration is saved in the Admin.
+
+**For those who do not use the Admin Plugin**, before configuring this plugin, you should copy the `user/plugins/{{ component_hyphenated }}/{{ component_hyphenated }}.yaml` to `user/config/plugins/{{ component_hyphenated }}.yaml` and only edit that copy.
 
 Here is the default configuration and an explanation of available options:
 
@@ -43,7 +45,6 @@ Here is the default configuration and an explanation of available options:
 enabled: true
 ```
 
-Note that if you use the Admin Plugin, a file with your configuration named {{component_hyphenated}}.yaml will be saved in the `user/config/plugins/`-folder once the configuration is saved in the Admin.
 
 ## Usage
 


### PR DESCRIPTION
Updated Default README for the generated plugin.
I noticed that most plugin developers left this part untouched and I thought this wording suggested that installation via admin is the least preferrable way (whereas it is the most user-friendly).

I also clarified sooner that there is no need to copy the config file when using the admin plugin.